### PR TITLE
Extend parser to support ESMR V5.0

### DIFF
--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -107,8 +107,18 @@ function parsePacket(packet) {
                     }
                 },
                 harmonics: {
-                    reading: null,
-                    unit: null
+                    L1: {
+                        reading: null,
+                        unit: null
+                    },
+                    L2: {
+                        reading: null,
+                        unit: null
+                    },
+                    L3: {
+                        reading: null,
+                        unit: null
+                    }
                 }
             }
         },
@@ -332,8 +342,16 @@ function parsePacket(packet) {
                     break;
 
                 case "1-0:32.7.0":
-                    parsedPacket.electricity.instantaneous.harmonics.reading = parseFloat(line.value);
-                    parsedPacket.electricity.instantaneous.harmonics.unit = line.unit;
+                    parsedPacket.electricity.instantaneous.harmonics.L1.reading = parseFloat(line.value);
+                    parsedPacket.electricity.instantaneous.harmonics.L1.unit = line.unit;
+                    break;
+                case "1-0:52.7.0":
+                    parsedPacket.electricity.instantaneous.harmonics.L2.reading = parseFloat(line.value);
+                    parsedPacket.electricity.instantaneous.harmonics.L2.unit = line.unit;
+                    break;
+                case "1-0:72.7.0":
+                    parsedPacket.electricity.instantaneous.harmonics.L3.reading = parseFloat(line.value);
+                    parsedPacket.electricity.instantaneous.harmonics.L3.unit = line.unit;
                     break;
 
                 default:


### PR DESCRIPTION
I've moved/added the "harmonics" reading for all 3 phases since it is (in my system at least) provided for all phases.

This is a backwards compatible patch (at least if combined with my change in com.p1.smartmeter as well).